### PR TITLE
Mark natives as optional

### DIFF
--- a/scripting/include/tf2utils.inc
+++ b/scripting/include/tf2utils.inc
@@ -508,3 +508,57 @@ public SharedPlugin __pl_tf2utils = {
 	required = 0,
 #endif
 };
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_tf2utils_SetNTVOptional()
+{
+	MarkNativeAsOptional("TF2Util_TakeHealth");
+	MarkNativeAsOptional("TF2Util_GetPlayerMaxAmmo");
+	MarkNativeAsOptional("TF2Util_SetPlayerActiveWeapon");
+	MarkNativeAsOptional("TF2Util_GetEntityMaxHealth");
+	MarkNativeAsOptional("TF2Util_GetPlayerMaxHealthBoost");
+	MarkNativeAsOptional("TF2Util_GetConditionCount");
+	MarkNativeAsOptional("TF2Util_GetConditionName");
+	MarkNativeAsOptional("TF2Util_GetPlayerConditionDuration");
+	MarkNativeAsOptional("TF2Util_SetPlayerConditionDuration");
+	MarkNativeAsOptional("TF2Util_GetPlayerConditionProvider");
+	MarkNativeAsOptional("TF2Util_SetPlayerConditionProvider");
+	MarkNativeAsOptional("TF2Util_GetPlayerBurnDuration");
+	MarkNativeAsOptional("TF2Util_SetPlayerBurnDuration");
+	MarkNativeAsOptional("TF2Util_IgnitePlayer");
+	MarkNativeAsOptional("TF2Util_GetPlayerActiveBleedCount");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedAttacker");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedWeapon");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedNextDamageTick");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedDuration");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedDamage");
+	MarkNativeAsOptional("TF2Util_GetPlayerBleedCustomDamageType");
+	MarkNativeAsOptional("TF2Util_MakePlayerBleed");
+	MarkNativeAsOptional("TF2Util_IsPlayerImmuneToPushback");
+	MarkNativeAsOptional("TF2Util_GetPlayerRespawnTimeOverride");
+	MarkNativeAsOptional("TF2Util_SetPlayerRespawnTimeOverride");
+	MarkNativeAsOptional("TF2Util_GetPlayerShootPosition");
+	MarkNativeAsOptional("TF2Util_GetPlayerObject");
+	MarkNativeAsOptional("TF2Util_GetPlayerObjectCount");
+	MarkNativeAsOptional("TF2Util_GetPlayerHealer");
+	MarkNativeAsOptional("TF2Util_GetPlayerLastDamageReceivedTime");
+	MarkNativeAsOptional("TF2Util_IsEntityWeapon");
+	MarkNativeAsOptional("TF2Util_IsEntityWearable");
+	MarkNativeAsOptional("TF2Util_GetWeaponSlot");
+	MarkNativeAsOptional("TF2Util_GetWeaponID");
+	MarkNativeAsOptional("TF2Util_GetWeaponMaxClip");
+	MarkNativeAsOptional("TF2Util_CanWeaponAttack");
+	MarkNativeAsOptional("TF2Util_GetPlayerWearable");
+	MarkNativeAsOptional("TF2Util_GetPlayerWearableCount");
+	MarkNativeAsOptional("TF2Util_GetPlayerLoadoutEntity");
+	MarkNativeAsOptional("TF2Util_EquipPlayerWearable");
+	MarkNativeAsOptional("TF2Util_SetWearableAlwaysValid");
+	MarkNativeAsOptional("TF2Util_UpdatePlayerSpeed");
+	MarkNativeAsOptional("TF2Util_IsPointInRespawnRoom");
+	MarkNativeAsOptional("TF2Util_StartLagCompensation");
+	MarkNativeAsOptional("TF2Util_FinishLagCompensation");
+	MarkNativeAsOptional("TF2Util_IsCustomDamageTypeDOT");
+	MarkNativeAsOptional("TF2Util_GetPlayerFromSharedAddress");
+	MarkNativeAsOptional("TF2Util_GetPlayerMaxHealth");
+}
+#endif


### PR DESCRIPTION
Wanted to gate TF2Util usage behind LibraryExists calls to support x64 in my plugins but that doesn't work with them being required